### PR TITLE
Add Triglavian red loot to fixed-price list

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -5,7 +5,8 @@ var BLUE_LOOT = {
   'Ancient Coordinates Database': 1500000,
   'Neural Network Analyzer': 200000,
   'Sleeper Data Library': 500000,
-  'Sleeper Drone AI Nexus': 5000000
+  'Sleeper Drone AI Nexus': 5000000,
+  'Triglavian Survey Databse': 100000
 };
 
 /**

--- a/src/server.js
+++ b/src/server.js
@@ -6,7 +6,7 @@ var BLUE_LOOT = {
   'Neural Network Analyzer': 200000,
   'Sleeper Data Library': 500000,
   'Sleeper Drone AI Nexus': 5000000,
-  'Triglavian Survey Databse': 100000
+  'Triglavian Survey Database': 100000
 };
 
 /**


### PR DESCRIPTION
Red Loot from abyssal sites is also sold to NPC buy orders, so we should treat it the way we treat blue loot.